### PR TITLE
Make watchlist database path configurable via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ FINNHUB_API_KEY="your-finnhub-token"
 # Optional overrides
 PREMARKET_CONFIG_PATH="config/strategy.yaml"
 PREMARKET_OUT_DIR="data/watchlists"      # auto-appends YYYY-MM-DD
+PREMARKET_SHARED_DB="data/watchlists/watchlist.db"
 PREMARKET_TOP_N=20
 PREMARKET_USE_CACHE=true
 PREMARKET_NEWS_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ FINNHUB_API_KEY="your-finnhub-token"
 # Runtime overrides (all optional)
 PREMARKET_CONFIG_PATH="config/strategy.yaml"
 PREMARKET_OUT_DIR="data/watchlists"      # YYYY-MM-DD is auto-appended
+PREMARKET_SHARED_DB="data/watchlists/watchlist.db"  # static SQLite output location
 PREMARKET_TOP_N=20                        # override YAML top_n
 PREMARKET_USE_CACHE=true                  # allow fallback to cached CSV if download fails
 PREMARKET_NEWS_ENABLED=false              # force news probe on/off

--- a/premarket/__main__.py
+++ b/premarket/__main__.py
@@ -199,9 +199,16 @@ def main(argv: Optional[list[str]] = None) -> int:
         fail_on_empty = cli_fail
         overrides.add("PREMARKET_FAIL_ON_EMPTY")
 
+    watchlist_db_path: Optional[Path] = None
+    watchlist_db_env = utils.env_str("PREMARKET_SHARED_DB")
+    if watchlist_db_env is not None:
+        watchlist_db_path = Path(watchlist_db_env)
+        overrides.add("PREMARKET_SHARED_DB")
+
     params = orchestrate.RunParams(
         config_path=Path(config_value),
         output_base_dir=output_base,
+        watchlist_db_path=watchlist_db_path,
         top_n=top_n,
         use_cache=use_cache,
         news_override=news_override,


### PR DESCRIPTION
## Summary
- allow RunParams to resolve a configurable watchlist database path and persist workflow results there
- surface the PREMARKET_SHARED_DB environment override through the CLI bootstrap and document it in the README and example env file
- update orchestration end-to-end tests to exercise the fixed database path behaviour

## Testing
- pytest
- pytest tests/test_orchestrate_e2e.py

------
https://chatgpt.com/codex/tasks/task_e_68d9b0e02dc48331b592959bbecef814