### PR TITLE
Capture Finviz metadata for shortlist persistence

### DIFF
--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -59,3 +59,28 @@ def test_coerce_types_parses_suffixes():
     assert coerced.loc[0, "float_pct"] == 65.0
     assert coerced.loc[0, "short_float_pct"] == 12.5
     assert warnings == 0
+
+
+def test_normalize_preserves_company_and_sector():
+    df = pd.DataFrame(
+        {
+            "Ticker": ["CCC"],
+            "Company": ["Gamma Corp"],
+            "Sector": ["Industrials"],
+            "Price": ["$12.75"],
+            "Average Volume (3M)": ["1.2M"],
+            "Relative Volume": ["1.4"],
+        }
+    )
+
+    normalized = normalize.normalize_columns(df)
+    assert "company" in normalized.columns
+    assert "sector" in normalized.columns
+
+    coerced, warnings = normalize.coerce_types(normalized)
+    assert coerced.loc[0, "company"] == "Gamma Corp"
+    assert coerced.loc[0, "sector"] == "Industrials"
+    assert coerced.loc[0, "price"] == 12.75
+    assert coerced.loc[0, "avg_volume_3m"] == 1_200_000
+    assert coerced.loc[0, "rel_volume"] == 1.4
+    assert warnings == 0

--- a/tests/test_service_smoke.py
+++ b/tests/test_service_smoke.py
@@ -71,6 +71,10 @@ def test_premarket_scan_smoke(monkeypatch, tmp_path, fake_connection):
     _sample_csv(csv_path)
 
     fake_connection.securities = {"AAA": 101, "BBB": 202}
+    fake_connection.security_metadata = {
+        "AAA": {"name": "Legacy", "sector": "Old"},
+        "BBB": {"name": "Beta", "sector": "Healthcare"},
+    }
 
     tzinfo = tz.gettz("America/New_York")
     fixed_now = datetime(2024, 1, 2, 8, 45, tzinfo=tzinfo)
@@ -115,6 +119,10 @@ def test_premarket_scan_smoke(monkeypatch, tmp_path, fake_connection):
     assert len(fake_connection.shortlists) == len(result.top_symbols)
     stored_symbol_ids = {row[1] for row in fake_connection.shortlists}
     assert stored_symbol_ids == {101, 202}
+    assert fake_connection.security_metadata["AAA"]["name"] == "Alpha"
+    assert fake_connection.security_metadata["AAA"]["sector"] == "Technology"
+    assert fake_connection.security_metadata["BBB"]["name"] == "Beta"
+    assert fake_connection.security_metadata["BBB"]["sector"] == "Healthcare"
     diversified = result.diversified_df.to_dict(orient="records")
     rows_by_symbol = {row["ticker"]: row for row in diversified}
     id_to_symbol = {identifier: symbol for symbol, identifier in fake_connection.securities.items()}


### PR DESCRIPTION
## Summary
- upsert Finviz company and sector metadata into `securities` before writing shortlist rows
- extend the fake MySQL test harness to record security metadata updates and cover repeated runs
- add Finviz normalization coverage for the new descriptive fields

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_69080aa601848331a6a43e759f5f8446